### PR TITLE
Package migration to Dart 2.0

### DIFF
--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -102,7 +102,9 @@ class AddressComponent {
 
   factory AddressComponent.fromJson(Map json) => json != null
       ? new AddressComponent(
-          json["types"] as List<String>, json["long_name"], json["short_name"])
+          (json["types"] as List)?.cast<String>(),
+          json["long_name"],
+          json["short_name"])
       : null;
 }
 

--- a/lib/src/directions.dart
+++ b/lib/src/directions.dart
@@ -165,7 +165,7 @@ class GoogleMapsDirections extends GoogleWebService {
   }
 
   DirectionsResponse _decode(Response res) =>
-      new DirectionsResponse.fromJson(JSON.decode(res.body));
+      new DirectionsResponse.fromJson(json.decode(res.body));
 }
 
 class DirectionsResponse extends GoogleResponseStatus {

--- a/lib/src/directions.dart
+++ b/lib/src/directions.dart
@@ -183,10 +183,10 @@ class DirectionsResponse extends GoogleResponseStatus {
       json["error_message"],
       json["geocoded_waypoints"]?.map((r) {
         return new GeocodedWaypoint.fromJson(r);
-      })?.toList() as List<GeocodedWaypoint>,
+      })?.toList()?.cast<GeocodedWaypoint>(),
       json["routes"]?.map((r) {
         return new Route.fromJson(r);
-      })?.toList() as List<Route>);
+      })?.toList()?.cast<Route>());
 }
 
 class Waypoint {
@@ -226,7 +226,7 @@ class GeocodedWaypoint {
   factory GeocodedWaypoint.fromJson(Map json) => new GeocodedWaypoint(
       json["geocoder_status"],
       json["place_id"],
-      json["types"] as List<String>,
+      (json["types"] as List)?.cast<String>(),
       json["partial_match"]);
 }
 
@@ -255,11 +255,11 @@ class Route {
           json["summary"],
           json["legs"]?.map((r) {
             return new Leg.fromJson(r);
-          })?.toList() as List<Leg>,
+          })?.toList()?.cast<Leg>(),
           json["copyrights"],
           new Polyline.fromJson(json["overview_polyline"]),
           json["warnings"] as List,
-          json["waypoint_order"] as List<num>,
+          (json["waypoint_order"] as List)?.cast<num>(),
           new Bounds.fromJson(json["bounds"]),
           new Fare.fromJson(json["fare"]))
       : null;
@@ -314,7 +314,7 @@ class Leg extends _Step {
       ? new Leg(
           json["steps"]?.map((r) {
             return new Step.fromJson(r);
-          })?.toList() as List<Step>,
+          })?.toList()?.cast<Step>(),
           json["start_address"],
           json["end_address"],
           new Value.fromJson(json["duration_in_traffic"]),

--- a/lib/src/geocoding.dart
+++ b/lib/src/geocoding.dart
@@ -102,7 +102,7 @@ class GeocodingResponse extends GoogleResponseList<GeocodingResult> {
           json["error_message"],
           json["results"].map((r) {
             return new GeocodingResult.fromJson(r);
-          }).toList() as List<GeocodingResult>)
+          }).toList().cast<GeocodingResult>())
       : null;
 }
 
@@ -131,12 +131,12 @@ class GeocodingResult {
 
   factory GeocodingResult.fromJson(Map json) => json != null
       ? new GeocodingResult(
-          json["types"] as List<String>,
+          (json["types"] as List)?.cast<String>(),
           json["formatted_address"],
           json["address_components"]
               .map((addr) => new AddressComponent.fromJson(addr))
-              .toList() as List<AddressComponent>,
-          json["postcode_localities"] as List<String>,
+              .toList().cast<AddressComponent>(),
+          (json["postcode_localities"] as List)?.cast<String>(),
           new Geometry.fromJson(json["geometry"]),
           json["partial_match"],
           json["place_id"])

--- a/lib/src/geocoding.dart
+++ b/lib/src/geocoding.dart
@@ -88,7 +88,7 @@ class GoogleMapsGeocoding extends GoogleWebService {
   }
 
   GeocodingResponse _decode(Response res) =>
-      new GeocodingResponse.fromJson(JSON.decode(res.body));
+      new GeocodingResponse.fromJson(json.decode(res.body));
 }
 
 class GeocodingResponse extends GoogleResponseList<GeocodingResult> {

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -284,8 +284,8 @@ class PlacesSearchResponse extends GoogleResponseList<PlacesSearchResult> {
           json["error_message"],
           json["results"]
               .map((r) => new PlacesSearchResult.fromJson(r))
-              .toList() as List<PlacesSearchResult>,
-          json["html_attributions"] as List<String>,
+              .toList().cast<PlacesSearchResult>(),
+          (json["html_attributions"] as List).cast<String>(),
           json["next_page_token"])
       : null;
 }
@@ -352,16 +352,16 @@ class PlacesSearchResult {
           json["name"],
           new OpeningHours.fromJson(json["opening_hours"]),
           json["photos"]?.map((p) => new Photo.fromJson(p))?.toList()
-              as List<Photo>,
+              ?.cast<Photo>(),
           json["place_id"],
           json["scope"],
           json["alt_ids"]?.map((a) => new AlternativeId.fromJson(a))?.toList()
-              as List<AlternativeId>,
+              ?.cast<AlternativeId>(),
           json["price_level"] != null
               ? PriceLevel.values.elementAt(json["price_level"])
               : null,
           json["rating"],
-          json["types"] as List<String>,
+          (json["types"] as List)?.cast<String>(),
           json["vicinity"],
           json["formatted_address"],
           json["permanently_closed"],
@@ -441,7 +441,7 @@ class PlaceDetails {
       ? new PlaceDetails(
           json["address_components"]
               .map((addr) => new AddressComponent.fromJson(addr))
-              .toList() as List<AddressComponent>,
+              .toList().cast<AddressComponent>(),
           json["adr_address"],
           json["formatted_address"],
           json["formatted_phone_number"],
@@ -453,13 +453,13 @@ class PlaceDetails {
           json["international_phone_number"],
           json["rating"],
           json["scope"],
-          json["types"] as List<String>,
+          (json["types"] as List)?.cast<String>(),
           json["url"],
           json["vicinity"],
           json["utc_offset"],
           json["website"],
           json["reviews"]?.map((r) => new Review.fromJson(r))?.toList()
-              as List<Review>,
+              ?.cast<Review>(),
           new Geometry.fromJson(json["geometry"]))
       : null;
 }
@@ -487,7 +487,7 @@ class Photo {
 
   factory Photo.fromJson(Map json) => json != null
       ? new Photo(json["photo_reference"], json["height"], json["width"],
-          json["html_attributions"] as List<String>)
+          (json["html_attributions"] as List)?.cast<String>())
       : null;
 }
 
@@ -518,7 +518,7 @@ class PlacesDetailsResponse extends GoogleResponse<PlaceDetails> {
           json["status"],
           json["error_message"],
           new PlaceDetails.fromJson(json["result"]),
-          json["html_attributions"] as List<String>)
+              (json["html_attributions"] as List)?.cast<String>())
       : null;
 }
 
@@ -571,7 +571,7 @@ class PlacesAutocompleteResponse extends GoogleResponseStatus {
           json["status"],
           json["error_message"],
           json["predictions"].map((p) => new Prediction.fromJson(p)).toList()
-              as List<Prediction>)
+              .cast<Prediction>())
       : null;
 }
 
@@ -596,13 +596,13 @@ class Prediction {
           json["description"],
           json["id"],
           json["terms"]?.map((t) => new Term.fromJson(t))?.toList()
-              as List<Term>,
+              ?.cast<Term>(),
           json["place_id"],
           json["reference"],
-          json["types"] as List<String>,
+          (json["types"] as List)?.cast<String>(),
           json["matched_substrings"]
               ?.map((m) => new MatchedSubstring.fromJson(m))
-              ?.toList() as List<MatchedSubstring>)
+              ?.toList()?.cast<MatchedSubstring>())
       : null;
 }
 

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -254,13 +254,13 @@ class GoogleMapsPlaces extends GoogleWebService {
   }
 
   PlacesSearchResponse _decodeSearchResponse(Response res) =>
-      new PlacesSearchResponse.fromJson(JSON.decode(res.body));
+      new PlacesSearchResponse.fromJson(json.decode(res.body));
 
   PlacesDetailsResponse _decodeDetailsResponse(Response res) =>
-      new PlacesDetailsResponse.fromJson(JSON.decode(res.body));
+      new PlacesDetailsResponse.fromJson(json.decode(res.body));
 
   PlacesAutocompleteResponse _decodeAutocompleteResponse(Response res) =>
-      new PlacesAutocompleteResponse.fromJson(JSON.decode(res.body));
+      new PlacesAutocompleteResponse.fromJson(json.decode(res.body));
 }
 
 class PlacesSearchResponse extends GoogleResponseList<PlacesSearchResult> {

--- a/test/directions_test.dart
+++ b/test/directions_test.dart
@@ -262,7 +262,7 @@ launch([Client client]) async {
 
     test("decode response", () {
       DirectionsResponse response =
-          new DirectionsResponse.fromJson(JSON.decode(_responseExample));
+          new DirectionsResponse.fromJson(json.decode(_responseExample));
 
       expect(response.isOkay, isTrue);
       expect(response.routes, hasLength(equals(1)));

--- a/test/geocoding_test.dart
+++ b/test/geocoding_test.dart
@@ -74,7 +74,7 @@ launch([Client client]) async {
 
     test("decode response", () {
       GeocodingResponse response =
-          new GeocodingResponse.fromJson(JSON.decode(_responseExample));
+          new GeocodingResponse.fromJson(json.decode(_responseExample));
 
       expect(response.isOkay, isTrue);
       expect(response.results, hasLength(equals(1)));

--- a/test/places_test.dart
+++ b/test/places_test.dart
@@ -331,7 +331,7 @@ launch([Client client]) async {
 
     test("decode response", () {
       PlacesSearchResponse response =
-          new PlacesSearchResponse.fromJson(JSON.decode(_responseExample));
+          new PlacesSearchResponse.fromJson(json.decode(_responseExample));
 
       expect(response.isOkay, isTrue);
       expect(response.results, hasLength(equals(4)));


### PR DESCRIPTION
The PR includes two fixes that make the package compatible with Dart 2.0

In the first change ``List`` references have been casted to the adequate type using ``cast<T>()`` according to the suggestion in the [dartlang.org sound-poblems guide](https://www.dartlang.org/guides/language/sound-problems#fix-tighten-or-correct-types).

The second change replaces the deprecated ``JSON`` with ``json``.

After this changes, all the test in the test directory pass without issues.