### PR TITLE
Add opening_hours, price, and photos to PlaceDetails

### DIFF
--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -400,6 +400,8 @@ class PlaceDetails {
   /// JSON opening_hours
   final OpeningHoursDetail openingHours;
 
+  final List<Photo> photos;
+
   /// JSON place_id
   final String placeId;
 
@@ -438,6 +440,7 @@ class PlaceDetails {
       this.icon,
       this.name,
       this.openingHours,
+      this.photos,
       this.placeId,
       this.internationalPhoneNumber,
       this.priceLevel,
@@ -465,6 +468,10 @@ class PlaceDetails {
           json["icon"],
           json["name"],
           json["opening_hours"],
+          json["photos"]
+              ?.map((p) => new Photo.fromJson(p))
+              ?.toList()
+              ?.cast<Photo>(),
           json["place_id"],
           json["international_phone_number"],
           json["price_level"] != null

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -397,6 +397,9 @@ class PlaceDetails {
 
   final String name;
 
+  /// JSON opening_hours
+  final OpeningHoursDetail openingHours;
+
   /// JSON place_id
   final String placeId;
 
@@ -431,6 +434,7 @@ class PlaceDetails {
       this.reference,
       this.icon,
       this.name,
+      this.openingHours,
       this.placeId,
       this.internationalPhoneNumber,
       this.rating,
@@ -456,6 +460,7 @@ class PlaceDetails {
           json["reference"],
           json["icon"],
           json["name"],
+          json["opening_hours"],
           json["place_id"],
           json["international_phone_number"],
           json["rating"],
@@ -481,6 +486,44 @@ class OpeningHours {
 
   factory OpeningHours.fromJson(Map json) =>
       json != null ? new OpeningHours(json["open_now"]) : null;
+}
+
+class OpeningHoursDetail extends OpeningHours {
+  final List<OpeningHoursPeriod> periods;
+  final List<String> weekdayText;
+
+  OpeningHoursDetail(openNow, this.periods, this.weekdayText) : super(openNow);
+
+  factory OpeningHoursDetail.fromJson(Map json) => json != null
+    ? new OpeningHoursDetail(
+        json["open_now"],
+        json["periods"]
+          ?.map((p) => new OpeningHoursPeriod.fromJSON(p))
+          ?.toList()
+          ?.cast<OpeningHoursPeriod>(),
+        json["weekday_text"]
+      )
+    : null;
+}
+
+class OpeningHoursPeriod {
+  final DateTime open;
+  final DateTime close;
+
+  OpeningHoursPeriod(this.open, this.close);
+
+  static DateTime _jsonToDateTime(Map<String, dynamic> json) {
+    final _now = new DateTime.now();
+    // Maps is 0-index DOW
+    final _weekday = _now.weekday - 1;
+    final _mondayOfThisWeek = _now.day - _weekday;
+    final _computedWeekday = _mondayOfThisWeek + json["day"] as int;
+
+    return new DateTime(_now.year, _now.month, _computedWeekday, json["time"] as int);
+  }
+
+  factory OpeningHoursPeriod.fromJSON(Map json) =>
+    json != null ? OpeningHoursPeriod(_jsonToDateTime(json["open"]), _jsonToDateTime(json["close"])) : null;
 }
 
 class Photo {

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -406,6 +406,9 @@ class PlaceDetails {
   /// JSON international_phone_number
   final String internationalPhoneNumber;
 
+  /// JSON price_level
+  final PriceLevel priceLevel;
+
   final num rating;
 
   final String scope;
@@ -437,6 +440,7 @@ class PlaceDetails {
       this.openingHours,
       this.placeId,
       this.internationalPhoneNumber,
+      this.priceLevel,
       this.rating,
       this.scope,
       this.types,
@@ -463,6 +467,9 @@ class PlaceDetails {
           json["opening_hours"],
           json["place_id"],
           json["international_phone_number"],
+          json["price_level"] != null
+              ? PriceLevel.values.elementAt(json["price_level"])
+              : null,
           json["rating"],
           json["scope"],
           (json["types"] as List)?.cast<String>(),

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -512,7 +512,7 @@ class OpeningHoursDetail extends OpeningHours {
     ? new OpeningHoursDetail(
         json["open_now"],
         json["periods"]
-          ?.map((p) => new OpeningHoursPeriod.fromJSON(p))
+          ?.map((p) => new OpeningHoursPeriod.fromJson(p))
           ?.toList()
           ?.cast<OpeningHoursPeriod>(),
         (json["weekday_text"] as List)?.cast<String>()
@@ -520,29 +520,33 @@ class OpeningHoursDetail extends OpeningHours {
     : null;
 }
 
-class OpeningHoursPeriod {
+class OpeningHoursPeriodDate extends GoogleDateTime {
+  final int day;
+  final String time;
+
   /// UTC Time
-  final DateTime open;
-  /// UTC Time
-  final DateTime close;
+  DateTime dateTime;
+
+  OpeningHoursPeriodDate(this.day, this.time) {
+    dateTime = dayTimeToDateTime(this.day, this.time);
+  }
+
+  factory OpeningHoursPeriodDate.fromJson(Map json) =>
+    json != null ? OpeningHoursPeriodDate(json["day"], json["time"]) : null;
+}
+
+class OpeningHoursPeriod extends GoogleDateTime {
+  final OpeningHoursPeriodDate open;
+  final OpeningHoursPeriodDate close;
 
   OpeningHoursPeriod(this.open, this.close);
 
-  static DateTime _jsonToDateTime(Map<String, dynamic> json) {
-    final _now = new DateTime.now();
-    // Maps is 0-index DOW
-    final _weekday = _now.weekday - 1;
-    final _mondayOfThisWeek = _now.day - _weekday;
-    final _computedWeekday = _mondayOfThisWeek + json["day"];
-
-    final _hour = int.parse((json["time"] as String).substring(0, 2));
-    final _minute = int.parse((json["time"] as String).substring(2));
-
-    return new DateTime.utc(_now.year, _now.month, _computedWeekday, _hour, _minute);
-  }
-
-  factory OpeningHoursPeriod.fromJSON(Map json) =>
-    json != null ? OpeningHoursPeriod(_jsonToDateTime(json["open"]), _jsonToDateTime(json["close"])) : null;
+  factory OpeningHoursPeriod.fromJson(Map json) => json != null
+    ? OpeningHoursPeriod(
+        OpeningHoursPeriodDate.fromJson(json["open"]),
+        OpeningHoursPeriodDate.fromJson(json["close"])
+      )
+    : null;
 }
 
 class Photo {

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -521,7 +521,9 @@ class OpeningHoursDetail extends OpeningHours {
 }
 
 class OpeningHoursPeriod {
+  /// UTC Time
   final DateTime open;
+  /// UTC Time
   final DateTime close;
 
   OpeningHoursPeriod(this.open, this.close);
@@ -533,7 +535,10 @@ class OpeningHoursPeriod {
     final _mondayOfThisWeek = _now.day - _weekday;
     final _computedWeekday = _mondayOfThisWeek + json["day"];
 
-    return new DateTime(_now.year, _now.month, _computedWeekday, int.parse(json["time"]));
+    final _hour = int.parse((json["time"] as String).substring(0, 2));
+    final _minute = int.parse((json["time"] as String).substring(2));
+
+    return new DateTime.utc(_now.year, _now.month, _computedWeekday, _hour, _minute);
   }
 
   factory OpeningHoursPeriod.fromJSON(Map json) =>

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -467,7 +467,7 @@ class PlaceDetails {
           json["reference"],
           json["icon"],
           json["name"],
-          json["opening_hours"],
+          new OpeningHoursDetail.fromJson(json["opening_hours"]),
           json["photos"]
               ?.map((p) => new Photo.fromJson(p))
               ?.toList()
@@ -508,14 +508,14 @@ class OpeningHoursDetail extends OpeningHours {
 
   OpeningHoursDetail(openNow, this.periods, this.weekdayText) : super(openNow);
 
-  factory OpeningHoursDetail.fromJson(Map json) => json != null
+  factory OpeningHoursDetail.fromJson(Map<String, dynamic> json) => json != null
     ? new OpeningHoursDetail(
         json["open_now"],
         json["periods"]
           ?.map((p) => new OpeningHoursPeriod.fromJSON(p))
           ?.toList()
           ?.cast<OpeningHoursPeriod>(),
-        json["weekday_text"]
+        (json["weekday_text"] as List)?.cast<String>()
       )
     : null;
 }
@@ -531,9 +531,9 @@ class OpeningHoursPeriod {
     // Maps is 0-index DOW
     final _weekday = _now.weekday - 1;
     final _mondayOfThisWeek = _now.day - _weekday;
-    final _computedWeekday = _mondayOfThisWeek + json["day"] as int;
+    final _computedWeekday = _mondayOfThisWeek + json["day"];
 
-    return new DateTime(_now.year, _now.month, _computedWeekday, json["time"] as int);
+    return new DateTime(_now.year, _now.month, _computedWeekday, int.parse(json["time"]));
   }
 
   factory OpeningHoursPeriod.fromJSON(Map json) =>

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -47,3 +47,25 @@ abstract class GoogleWebService {
   @protected
   Future<Response> doGet(String url) => httpClient.get(url);
 }
+
+abstract class GoogleDateTime {
+  @visibleForTesting
+  @protected
+  DateTime dayTimeToDateTime(int day, String time) {
+    if (time.length < 4) {
+      throw new ArgumentError(
+          "'time' is not a valid string. It must be four integers.");
+    }
+
+    final _now = new DateTime.now();
+    // Maps is 0-index DOW
+    final _weekday = _now.weekday - 1;
+    final _mondayOfThisWeek = _now.day - _weekday;
+    final _computedWeekday = _mondayOfThisWeek + day;
+
+    final _hour = int.parse(time.substring(0, 2));
+    final _minute = int.parse(time.substring(2));
+
+    return new DateTime.utc(_now.year, _now.month, _computedWeekday, _hour, _minute);
+  }
+}

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -1,9 +1,11 @@
 import 'geocoding_test.dart' as geocoding;
 import 'places_test.dart' as places;
 import 'directions_test.dart' as directions;
+import 'utils_test.dart' as utils;
 
 main() {
   geocoding.launch();
   places.launch();
   directions.launch();
+  utils.launch();
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -1,0 +1,46 @@
+library google_maps_webservice.utils.test;
+
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+import 'package:google_maps_webservice/src/utils.dart';
+
+class DateTimeInstance extends GoogleDateTime {}
+
+launch([Client client]) async {
+  group("Google Maps Utils", () {
+    group("abstract class GoogleDateTime", () {
+      DateTimeInstance utility;
+
+      setUpAll(() {
+        utility = DateTimeInstance();
+      });
+
+      group("dayTimeToDateTime", () {
+        test("basic", () {
+          final DateTime mondayAt1130 = utility.dayTimeToDateTime(0, "2330");
+
+          expect(
+            mondayAt1130.weekday,
+            equals(1)
+          );
+          expect(
+            mondayAt1130.hour,
+            equals(23)
+          );
+          expect(
+            mondayAt1130.minute,
+            equals(30)
+          );
+        });
+        test("throws for an invalid time argument", () {
+          expect(
+            () => utility.dayTimeToDateTime(0, "230"),
+            throwsArgumentError
+          );
+        });
+      });
+    });
+  });
+}
+
+main() => launch();


### PR DESCRIPTION
The response from Google is different between the SearchResults and Details; this PR massages some of those differences (chiefly the `opening_hours` discrepancy). 

That said, I'd like to flag how this PR handles `opening_hours`. For easy end-use, I converted the provided hours into a `DateTime` based on the current week. This may be problematic for querying places in non-local time zones. The alternative is to pass along the API's data (e.g. `day: 0, time: '2300'`) and let the end user do the heavy lifting.