### PR TITLE
added sesstiontoken autocomplete search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.10
+
+- added session token parameter for autocomplete search
+
 ## 0.0.9
 
 - fix partial match type in geocoding

--- a/example/places_autocomplete.dart
+++ b/example/places_autocomplete.dart
@@ -6,7 +6,8 @@ import 'package:google_maps_webservice/places.dart';
 final places = new GoogleMapsPlaces(Platform.environment["API_KEY"]);
 
 main() async {
-  PlacesAutocompleteResponse res = await places.autocomplete("Amoeba");
+  String sessionToken = "xyzabc_1234";
+  PlacesAutocompleteResponse res = await places.autocomplete("Amoeba", sessionToken: sessionToken);
 
   if (res.isOkay) {
     // list autocomplete prediction
@@ -16,7 +17,7 @@ main() async {
 
     // get detail of the first result
     PlacesDetailsResponse details =
-        await places.getDetailsByPlaceId(res.predictions.first.placeId);
+        await places.getDetailsByPlaceId(res.predictions.first.placeId, sessionToken: sessionToken);
 
     print("\nDetails :");
     print(details.result.formattedAddress);

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -83,21 +83,22 @@ class GoogleMapsPlaces extends GoogleWebService {
   }
 
   Future<PlacesDetailsResponse> getDetailsByPlaceId(String placeId,
-      {String extensions, String language}) async {
+      {String sessionToken, String extensions, String language}) async {
     final url = buildDetailsUrl(
-        placeId: placeId, extensions: extensions, language: language);
+        placeId: placeId, sessionToken: sessionToken, extensions: extensions, language: language);
     return _decodeDetailsResponse(await doGet(url));
   }
 
   Future<PlacesDetailsResponse> getDetailsByReference(String reference,
-      {String extensions, String language}) async {
+      {String sessionToken, String extensions, String language}) async {
     final url = buildDetailsUrl(
-        reference: reference, extensions: extensions, language: language);
+        reference: reference, sessionToken: sessionToken, extensions: extensions, language: language);
     return _decodeDetailsResponse(await doGet(url));
   }
 
   Future<PlacesAutocompleteResponse> autocomplete(String input,
-      {num offset,
+      {String sessionToken,
+      num offset,
       Location location,
       num radius,
       String language,
@@ -105,6 +106,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       List<Component> components,
       bool strictbounds}) async {
     final url = buildAutocompleteUrl(
+        sessionToken: sessionToken,
         input: input,
         location: location,
         offset: offset,
@@ -195,7 +197,7 @@ class GoogleMapsPlaces extends GoogleWebService {
   }
 
   String buildDetailsUrl(
-      {String placeId, String reference, String extensions, String language}) {
+      {String placeId, String reference, String sessionToken, String extensions, String language}) {
     if (placeId != null && reference != null) {
       throw new ArgumentError(
           "You must supply either 'placeid' or 'reference'");
@@ -208,12 +210,16 @@ class GoogleMapsPlaces extends GoogleWebService {
       "language": language,
       "extensions": extensions
     };
+    if(sessionToken != null){
+      params.putIfAbsent("sessiontoken", ()=>sessionToken);
+    }
 
     return "$url$_detailsSearchUrl?${buildQuery(params)}";
   }
 
   String buildAutocompleteUrl(
       {String input,
+      String sessionToken,
       num offset,
       Location location,
       num radius,
@@ -232,6 +238,9 @@ class GoogleMapsPlaces extends GoogleWebService {
       "strictbounds": strictbounds,
       "offset": offset
     };
+    if(sessionToken != null){
+      params.putIfAbsent("sessiontoken", () => sessionToken);
+    }
 
     return "$url$_autocompleteUrl?${buildQuery(params)}";
   }

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -85,14 +85,20 @@ class GoogleMapsPlaces extends GoogleWebService {
   Future<PlacesDetailsResponse> getDetailsByPlaceId(String placeId,
       {String sessionToken, String extensions, String language}) async {
     final url = buildDetailsUrl(
-        placeId: placeId, sessionToken: sessionToken, extensions: extensions, language: language);
+        placeId: placeId,
+        sessionToken: sessionToken,
+        extensions: extensions,
+        language: language);
     return _decodeDetailsResponse(await doGet(url));
   }
 
   Future<PlacesDetailsResponse> getDetailsByReference(String reference,
       {String sessionToken, String extensions, String language}) async {
     final url = buildDetailsUrl(
-        reference: reference, sessionToken: sessionToken, extensions: extensions, language: language);
+        reference: reference,
+        sessionToken: sessionToken,
+        extensions: extensions,
+        language: language);
     return _decodeDetailsResponse(await doGet(url));
   }
 
@@ -197,7 +203,11 @@ class GoogleMapsPlaces extends GoogleWebService {
   }
 
   String buildDetailsUrl(
-      {String placeId, String reference, String sessionToken, String extensions, String language}) {
+      {String placeId,
+      String reference,
+      String sessionToken,
+      String extensions,
+      String language}) {
     if (placeId != null && reference != null) {
       throw new ArgumentError(
           "You must supply either 'placeid' or 'reference'");
@@ -210,8 +220,8 @@ class GoogleMapsPlaces extends GoogleWebService {
       "language": language,
       "extensions": extensions
     };
-    if(sessionToken != null){
-      params.putIfAbsent("sessiontoken", ()=>sessionToken);
+    if (sessionToken != null) {
+      params.putIfAbsent("sessiontoken", () => sessionToken);
     }
 
     return "$url$_detailsSearchUrl?${buildQuery(params)}";
@@ -238,7 +248,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       "strictbounds": strictbounds,
       "offset": offset
     };
-    if(sessionToken != null){
+    if (sessionToken != null) {
       params.putIfAbsent("sessiontoken", () => sessionToken);
     }
 


### PR DESCRIPTION
According to https://developers.google.com/places/web-service/autocomplete#session_tokens
the autocomplete api provides a session token for grouping autocomplete searches.
Google will not charge an autocomplete search until a full autocomplete result is returned.

For this reason the PR provides a new parameter sessionToken on the apis autocomplete, getDetailsByPlaceId and getDetailsByReference.