### PR TITLE
Configurable base url and optional apiKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.10
+
+- introduced configurable base url
+- changed apiKey to an optional named parameter
+
 ## 0.0.9
 
 - fix partial match type in geocoding

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Google Maps Web Services [API](https://developers.google.com/maps/web-services)
 ```dart
 import "package:google_maps_webservice/geocoding.dart";
 
-final geocoding = new GoogleMapsGeocoding("<API_KEY>");
-final geocoding = new GoogleMapsGeocoding("<API_KEY>", new BrowserClient());
+final geocoding = new GoogleMapsGeocoding(apiKey: "<API_KEY>");
+final geocoding = new GoogleMapsGeocoding(apiKey: "<API_KEY>", httpClient: new BrowserClient());
+final geocoding = new GoogleMapsGeocoding(baseUrl: "http://myProxy.com");
 
 GeocodingResponse response = await geocoding.searchByAddress("1600 Amphitheatre Parkway, Mountain View, CA");
 ```
@@ -41,8 +42,9 @@ GeocodingResponse response = await geocoding.searchByAddress("1600 Amphitheatre 
 ```dart
 import "package:google_maps_webservice/places.dart";
 
-final places = new GoogleMapsPlaces("<API_KEY>");
-final places = new GoogleMapsPlaces("<API_KEY>", new BrowserClient());
+final places = new GoogleMapsPlaces(apiKey: "<API_KEY>");
+final places = new GoogleMapsPlaces(apiKey: "<API_KEY>", httpClient: new BrowserClient());
+final places = new GoogleMapsPlaces(baseUrl: "http://myProxy.com");
 
 PlacesSearchResponse reponse = await places.searchNearbyWithRadius(new Location(31.0424, 42.421), 500);
 PlacesSearchResponse reponse = await places.searchNearbyWithRankby(new Location(31.0424, 42.421), "distance");
@@ -51,6 +53,13 @@ PlacesSearchResponse reponse = await places.searchByText("123 Main Street");
 PlacesDetailsResponse response = await places.getDetailsByPlaceId("PLACE_ID");
 PlacesDetailsResponse response = await places.getDetailsByReference("REF");
 ```
+
+### Proxy
+
+In case of using a proxy the baseUrl can be set.
+The apiKey is not required in case the proxy sets it. (Not storing the apiKey in the app is good practice)
+
+### Feature Requests and Issues
 
 Please file feature requests and bugs at the [issue tracker][tracker].
 

--- a/example/directions.dart
+++ b/example/directions.dart
@@ -3,7 +3,7 @@ library google_maps_webservice.directions.example;
 import 'dart:io';
 import 'package:google_maps_webservice/directions.dart';
 
-final directions = new GoogleMapsDirections(Platform.environment["API_KEY"]);
+final directions = new GoogleMapsDirections(apiKey: Platform.environment["API_KEY"]);
 
 main() async {
   DirectionsResponse res =

--- a/example/places_autocomplete.dart
+++ b/example/places_autocomplete.dart
@@ -3,7 +3,7 @@ library google_maps_webservice.places.autocomplete.example;
 import 'dart:io';
 import 'package:google_maps_webservice/places.dart';
 
-final places = new GoogleMapsPlaces(Platform.environment["API_KEY"]);
+final places = new GoogleMapsPlaces(apiKey: Platform.environment["API_KEY"]);
 
 main() async {
   PlacesAutocompleteResponse res = await places.autocomplete("Amoeba");

--- a/lib/src/directions.dart
+++ b/lib/src/directions.dart
@@ -10,8 +10,8 @@ const _directionsUrl = "/directions/json";
 
 /// https://developers.google.com/maps/documentation/directions/start
 class GoogleMapsDirections extends GoogleWebService {
-  GoogleMapsDirections(String apiKey, [Client httpClient])
-      : super(apiKey, _directionsUrl, httpClient);
+  GoogleMapsDirections({String apiKey, String baseUrl, Client httpClient})
+      : super(apiKey: apiKey, baseUrl: baseUrl, url: _directionsUrl, httpClient: httpClient);
 
   Future<DirectionsResponse> directions(origin, destination,
       {TravelMode travelMode,
@@ -134,7 +134,6 @@ class GoogleMapsDirections extends GoogleWebService {
           "'arrivalTime' must be a '$num' or a '$DateTime'");
     }
     final params = {
-      "key": apiKey,
       "origin": origin != null && origin is String
           ? Uri.encodeComponent(origin)
           : origin,
@@ -160,6 +159,10 @@ class GoogleMapsDirections extends GoogleWebService {
       "transit_routing_preference":
           transitRoutingPreferencesToString(transitRoutingPreference)
     };
+
+    if(apiKey != null){
+      params.putIfAbsent("key", () => apiKey);
+    }
 
     return "$url?${buildQuery(params)}";
   }

--- a/lib/src/geocoding.dart
+++ b/lib/src/geocoding.dart
@@ -10,8 +10,8 @@ const _geocodeUrl = "/geocode/json";
 
 /// https://developers.google.com/maps/documentation/geocoding/start
 class GoogleMapsGeocoding extends GoogleWebService {
-  GoogleMapsGeocoding(String apiKey, [Client httpClient])
-      : super(apiKey, _geocodeUrl, httpClient);
+  GoogleMapsGeocoding({String apiKey, String baseUrl, Client httpClient})
+      : super(apiKey: apiKey, baseUrl: baseUrl, url: _geocodeUrl, httpClient: httpClient);
 
   Future<GeocodingResponse> searchByAddress(String address,
       {Bounds bounds,
@@ -72,7 +72,6 @@ class GoogleMapsGeocoding extends GoogleWebService {
       String placeId,
       Location location}) {
     final params = {
-      "key": apiKey,
       "latlng": location,
       "place_id": placeId,
       "address": address != null ? Uri.encodeComponent(address) : null,
@@ -83,6 +82,10 @@ class GoogleMapsGeocoding extends GoogleWebService {
       "result_type": resultType,
       "location_type": locationType
     };
+
+    if(apiKey != null){
+      params.putIfAbsent("key", () => apiKey);
+    }
 
     return "$url?${buildQuery(params)}";
   }

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -15,8 +15,8 @@ const _queryAutocompleteUrl = "/queryautocomplete/json";
 
 /// https://developers.google.com/places/web-service/
 class GoogleMapsPlaces extends GoogleWebService {
-  GoogleMapsPlaces(String apiKey, [Client httpClient])
-      : super(apiKey, _placesUrl, httpClient);
+  GoogleMapsPlaces({String apiKey, String baseUrl, Client httpClient})
+      : super(apiKey: apiKey, baseUrl: baseUrl, url: _placesUrl, httpClient: httpClient);
 
   Future<PlacesSearchResponse> searchNearbyWithRadius(
       Location location, num radius,
@@ -152,7 +152,6 @@ class GoogleMapsPlaces extends GoogleWebService {
     }
 
     final params = {
-      "key": apiKey,
       "location": location,
       "radius": radius,
       "language": language,
@@ -164,6 +163,10 @@ class GoogleMapsPlaces extends GoogleWebService {
       "rankby": rankby,
       "pagetoken": pagetoken
     };
+
+    if(apiKey != null){
+      params.putIfAbsent("key", () => apiKey);
+    }
 
     return "$url$_nearbySearchUrl?${buildQuery(params)}";
   }
@@ -179,7 +182,6 @@ class GoogleMapsPlaces extends GoogleWebService {
       String pagetoken,
       String language}) {
     final params = {
-      "key": apiKey,
       "query": query != null ? Uri.encodeComponent(query) : null,
       "language": language,
       "location": location,
@@ -190,6 +192,10 @@ class GoogleMapsPlaces extends GoogleWebService {
       "type": type,
       "pagetoken": pagetoken
     };
+
+    if(apiKey != null){
+      params.putIfAbsent("key", () => apiKey);
+    }
 
     return "$url$_textSearchUrl?${buildQuery(params)}";
   }
@@ -202,12 +208,15 @@ class GoogleMapsPlaces extends GoogleWebService {
     }
 
     final params = {
-      "key": apiKey,
       "placeid": placeId,
       "reference": reference,
       "language": language,
       "extensions": extensions
     };
+
+    if(apiKey != null){
+      params.putIfAbsent("key", () => apiKey);
+    }
 
     return "$url$_detailsSearchUrl?${buildQuery(params)}";
   }
@@ -222,7 +231,6 @@ class GoogleMapsPlaces extends GoogleWebService {
       List<Component> components,
       bool strictbounds}) {
     final params = {
-      "key": apiKey,
       "input": input != null ? Uri.encodeComponent(input) : null,
       "language": language,
       "location": location,
@@ -232,6 +240,9 @@ class GoogleMapsPlaces extends GoogleWebService {
       "strictbounds": strictbounds,
       "offset": offset
     };
+    if(apiKey != null){
+      params.putIfAbsent("key", () => apiKey);
+    }
 
     return "$url$_autocompleteUrl?${buildQuery(params)}";
   }
@@ -243,13 +254,16 @@ class GoogleMapsPlaces extends GoogleWebService {
       num radius,
       String language}) {
     final params = {
-      "key": apiKey,
       "input": input != null ? Uri.encodeComponent(input) : null,
       "language": language,
       "location": location,
       "radius": radius,
       "offset": offset
     };
+
+    if(apiKey != null){
+      params.putIfAbsent("key", () => apiKey);
+    }
 
     return "$url$_queryAutocompleteUrl?${buildQuery(params)}";
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -22,8 +22,9 @@ abstract class GoogleWebService {
 
   String get apiKey => _apiKey;
 
-  GoogleWebService(String apiKey, String url, [Client httpClient])
-      : _url = "$kGMapsUrl$url",
+  GoogleWebService({String apiKey, String baseUrl, @required String url, Client httpClient})
+      : assert(url != null),
+        _url = "${baseUrl??kGMapsUrl}$url",
         _httpClient = httpClient ?? new Client(),
         _apiKey = apiKey;
 

--- a/test/directions_test.dart
+++ b/test/directions_test.dart
@@ -22,7 +22,7 @@ launch([Client client]) async {
             directions.buildUrl(
                 origin: "Paris, France", destination: "Marseilles, France"),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=${Uri.encodeComponent("Paris, France")}&destination=${Uri.encodeComponent("Marseilles, France")}"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=${Uri.encodeComponent("Paris, France")}&destination=${Uri.encodeComponent("Marseilles, France")}&key=$apiKey"));
       });
 
       test("simple with Location origin/destination", () {
@@ -31,7 +31,7 @@ launch([Client client]) async {
                 origin: new Location(23.43, 65.1),
                 destination: new Location(62.323, 53.1)),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=23.43,65.1&destination=62.323,53.1"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=23.43,65.1&destination=62.323,53.1&key=$apiKey"));
       });
 
       test("simple with String/Location origin/destination", () {
@@ -40,7 +40,7 @@ launch([Client client]) async {
                 origin: new Location(23.43, 65.1),
                 destination: "Marseilles, France"),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=23.43,65.1&destination=${Uri.encodeComponent("Marseilles, France")}"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=23.43,65.1&destination=${Uri.encodeComponent("Marseilles, France")}&key=$apiKey"));
       });
 
       test("simple with bad type for origin/destination", () {
@@ -67,28 +67,28 @@ launch([Client client]) async {
                 destination: "Montreal",
                 avoid: RouteType.tolls),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&avoid=tolls"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&avoid=tolls&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 avoid: RouteType.highways),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&avoid=highways"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&avoid=highways&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 avoid: RouteType.indoor),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&avoid=indoor"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&avoid=indoor&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 avoid: RouteType.ferries),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&avoid=ferries"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&avoid=ferries&key=$apiKey"));
       });
 
       test("travel_mode", () {
@@ -98,28 +98,28 @@ launch([Client client]) async {
                 destination: "Montreal",
                 travelMode: TravelMode.bicycling),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&mode=bicycling"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&mode=bicycling&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 travelMode: TravelMode.driving),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&mode=driving"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&mode=driving&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 travelMode: TravelMode.transit),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&mode=transit"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&mode=transit&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 travelMode: TravelMode.walking),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&mode=walking"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&mode=walking&key=$apiKey"));
       });
 
       test("departure_time", () {
@@ -128,7 +128,7 @@ launch([Client client]) async {
             directions.buildUrl(
                 origin: "Toronto", destination: "Montreal", departureTime: d),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&departure_time=$d"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&departure_time=$d&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
@@ -136,7 +136,7 @@ launch([Client client]) async {
                 departureTime:
                     new DateTime.fromMillisecondsSinceEpoch(d * 1000)),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&departure_time=$d"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&departure_time=$d&key=$apiKey"));
       });
 
       test("arrival_time", () {
@@ -145,14 +145,14 @@ launch([Client client]) async {
             directions.buildUrl(
                 origin: "Toronto", destination: "Montreal", arrivalTime: d),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&arrival_time=$d"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&arrival_time=$d&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 arrivalTime: new DateTime.fromMillisecondsSinceEpoch(d * 1000)),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&arrival_time=$d"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&arrival_time=$d&key=$apiKey"));
       });
 
       test("units", () {
@@ -160,14 +160,14 @@ launch([Client client]) async {
             directions.buildUrl(
                 origin: "Toronto", destination: "Montreal", units: Unit.metric),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&units=metric"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&units=metric&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 units: Unit.imperial),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&units=imperial"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&units=imperial&key=$apiKey"));
       });
 
       test("traffic_model", () {
@@ -177,21 +177,21 @@ launch([Client client]) async {
                 destination: "Montreal",
                 trafficModel: TrafficModel.bestGuess),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&traffic_model=best_guess"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&traffic_model=best_guess&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 trafficModel: TrafficModel.pessimistic),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&traffic_model=pessimistic"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&traffic_model=pessimistic&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 trafficModel: TrafficModel.optimistic),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&traffic_model=optimistic"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&traffic_model=optimistic&key=$apiKey"));
       });
 
       test("transit_mode", () {
@@ -201,14 +201,14 @@ launch([Client client]) async {
                 destination: "Montreal",
                 transitMode: [TransitMode.rail]),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&transit_mode=rail"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&transit_mode=rail&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
                 destination: "Montreal",
                 transitMode: [TransitMode.bus]),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&transit_mode=bus"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&transit_mode=bus&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
@@ -219,7 +219,7 @@ launch([Client client]) async {
                   TransitMode.subway
                 ]),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&transit_mode=tram|train|subway"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&transit_mode=tram|train|subway&key=$apiKey"));
       });
 
       test("transit_routing_preference", () {
@@ -230,7 +230,7 @@ launch([Client client]) async {
                 transitRoutingPreference:
                     TransitRoutingPreferences.lessWalking),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&transit_routing_preference=less_walking"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&transit_routing_preference=less_walking&key=$apiKey"));
         expect(
             directions.buildUrl(
                 origin: "Toronto",
@@ -238,7 +238,7 @@ launch([Client client]) async {
                 transitRoutingPreference:
                     TransitRoutingPreferences.fewerTransfers),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&transit_routing_preference=fewer_transfers"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&transit_routing_preference=fewer_transfers&key=$apiKey"));
       });
 
       test("waypoints", () {
@@ -254,7 +254,7 @@ launch([Client client]) async {
                   Waypoint.fromEncodedPolyline("gfo}EtohhU")
                 ]),
             equals(
-                "https://maps.googleapis.com/maps/api/directions/json?key=$apiKey&origin=Toronto&destination=Montreal&waypoints=optimize:true|Paris|42.2,21.3|place_id:ChIJ3S-JXmauEmsRUcIaWtf4MzE|enc:gfo}EtohhU:"));
+                "https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&waypoints=optimize:true|Paris|42.2,21.3|place_id:ChIJ3S-JXmauEmsRUcIaWtf4MzE|enc:gfo}EtohhU:&key=$apiKey"));
       });
     });
 

--- a/test/directions_test.dart
+++ b/test/directions_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 launch([Client client]) async {
   final apiKey = "MY_API_KEY";
-  GoogleMapsDirections directions = new GoogleMapsDirections(apiKey, client);
+  GoogleMapsDirections directions = new GoogleMapsDirections(apiKey: apiKey, httpClient: client);
 
   tearDownAll(() {
     directions.dispose();

--- a/test/geocoding_test.dart
+++ b/test/geocoding_test.dart
@@ -8,7 +8,7 @@ import 'package:google_maps_webservice/geocoding.dart';
 
 launch([Client client]) async {
   final apiKey = "MY_API_KEY";
-  GoogleMapsGeocoding geocoding = new GoogleMapsGeocoding(apiKey, client);
+  GoogleMapsGeocoding geocoding = new GoogleMapsGeocoding(apiKey: apiKey, httpClient: client);
 
   tearDownAll(() {
     geocoding.dispose();

--- a/test/geocoding_test.dart
+++ b/test/geocoding_test.dart
@@ -22,7 +22,7 @@ launch([Client client]) async {
             geocoding.buildUrl(
                 address: "1600 Amphitheatre Parkway, Mountain View, CA"),
             equals(
-                "$kGMapsUrl/geocode/json?key=$apiKey&address=1600%20Amphitheatre%20Parkway%2C%20Mountain%20View%2C%20CA"));
+                "$kGMapsUrl/geocode/json?address=1600%20Amphitheatre%20Parkway%2C%20Mountain%20View%2C%20CA&key=$apiKey"));
       });
 
       test("address with bound", () {
@@ -32,21 +32,21 @@ launch([Client client]) async {
                 bounds: new Bounds(new Location(34.172684, -118.604794),
                     new Location(34.236144, -118.500938))),
             equals(
-                "$kGMapsUrl/geocode/json?key=$apiKey&address=Winnetka&bounds=34.172684,-118.604794|34.236144,-118.500938"));
+                "$kGMapsUrl/geocode/json?address=Winnetka&bounds=34.172684,-118.604794|34.236144,-118.500938&key=$apiKey"));
       });
 
       test("address with language", () {
         expect(
             geocoding.buildUrl(address: "Paris", language: "fr"),
             equals(
-                "$kGMapsUrl/geocode/json?key=$apiKey&address=Paris&language=fr"));
+                "$kGMapsUrl/geocode/json?address=Paris&language=fr&key=$apiKey"));
       });
 
       test("address with region", () {
         expect(
             geocoding.buildUrl(address: "Toledo", region: "es"),
             equals(
-                "$kGMapsUrl/geocode/json?key=$apiKey&address=Toledo&region=es"));
+                "$kGMapsUrl/geocode/json?address=Toledo&region=es&key=$apiKey"));
       });
 
       test("address with components", () {
@@ -55,21 +55,21 @@ launch([Client client]) async {
               new Component(Component.administrativeArea, "Toledo")
             ]),
             equals(
-                "$kGMapsUrl/geocode/json?key=$apiKey&address=Spain&components=administrative_area:Toledo"));
+                "$kGMapsUrl/geocode/json?address=Spain&components=administrative_area:Toledo&key=$apiKey"));
       });
 
       test("location", () {
         expect(
             geocoding.buildUrl(location: new Location(34.172684, -118.604794)),
             equals(
-                "https://maps.googleapis.com/maps/api/geocode/json?key=$apiKey&latlng=34.172684,-118.604794"));
+                "https://maps.googleapis.com/maps/api/geocode/json?latlng=34.172684,-118.604794&key=$apiKey"));
       });
 
       test("place_id", () {
         expect(
             geocoding.buildUrl(placeId: "f2hf1pn1rjr1"),
             equals(
-                "https://maps.googleapis.com/maps/api/geocode/json?key=$apiKey&place_id=f2hf1pn1rjr1"));
+                "https://maps.googleapis.com/maps/api/geocode/json?place_id=f2hf1pn1rjr1&key=$apiKey"));
       });
     });
 

--- a/test/places_test.dart
+++ b/test/places_test.dart
@@ -7,7 +7,7 @@ import 'package:google_maps_webservice/places.dart';
 
 launch([Client client]) async {
   final apiKey = "MY_API_KEY";
-  GoogleMapsPlaces places = new GoogleMapsPlaces(apiKey, client);
+  GoogleMapsPlaces places = new GoogleMapsPlaces(apiKey: apiKey, httpClient: client);
 
   tearDownAll(() {
     places.dispose();

--- a/test/places_test.dart
+++ b/test/places_test.dart
@@ -23,7 +23,7 @@ launch([Client client]) async {
         expect(
             url,
             equals(
-                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?key=$apiKey&location=-33.8670522,151.1957362&radius=500"));
+                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522,151.1957362&radius=500&key=$apiKey"));
       });
 
       test("with type and keyword", () {
@@ -36,7 +36,7 @@ launch([Client client]) async {
         expect(
             url,
             equals(
-                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?key=$apiKey&location=-33.8670522,151.1957362&radius=500&type=restaurant&keyword=cruise"));
+                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522,151.1957362&radius=500&type=restaurant&keyword=cruise&key=$apiKey"));
       });
 
       test("with language", () {
@@ -48,7 +48,7 @@ launch([Client client]) async {
         expect(
             url,
             equals(
-                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?key=$apiKey&location=-33.8670522,151.1957362&radius=500&language=fr"));
+                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522,151.1957362&radius=500&language=fr&key=$apiKey"));
       });
 
       test("with min and maxprice", () {
@@ -61,7 +61,7 @@ launch([Client client]) async {
         expect(
             url,
             equals(
-                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?key=$apiKey&location=-33.8670522,151.1957362&radius=500&minprice=0&maxprice=4"));
+                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522,151.1957362&radius=500&minprice=0&maxprice=4&key=$apiKey"));
       });
 
       test("build url with name", () {
@@ -73,7 +73,7 @@ launch([Client client]) async {
         expect(
             url,
             equals(
-                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?key=$apiKey&location=-33.8670522,151.1957362&radius=500&name=cruise"));
+                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522,151.1957362&radius=500&name=cruise&key=$apiKey"));
       });
 
       test("with rankby", () {
@@ -85,7 +85,7 @@ launch([Client client]) async {
         expect(
             url,
             equals(
-                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?key=$apiKey&location=-33.8670522,151.1957362&name=cruise&rankby=distance"));
+                "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522,151.1957362&name=cruise&rankby=distance&key=$apiKey"));
       });
 
       test("with rankby without required params", () {
@@ -122,7 +122,7 @@ launch([Client client]) async {
         expect(
             places.buildTextSearchUrl(query: "123 Main Street"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/textsearch/json?key=$apiKey&query=${Uri.encodeComponent("123 Main Street")}"));
+                "https://maps.googleapis.com/maps/api/place/textsearch/json?query=${Uri.encodeComponent("123 Main Street")}&key=$apiKey"));
       });
 
       test("with location", () {
@@ -131,21 +131,21 @@ launch([Client client]) async {
                 query: "123 Main Street",
                 location: new Location(-33.8670522, 151.1957362)),
             equals(
-                "https://maps.googleapis.com/maps/api/place/textsearch/json?key=$apiKey&query=${Uri.encodeComponent("123 Main Street")}&location=-33.8670522,151.1957362"));
+                "https://maps.googleapis.com/maps/api/place/textsearch/json?query=${Uri.encodeComponent("123 Main Street")}&location=-33.8670522,151.1957362&key=$apiKey"));
       });
 
       test("with radius", () {
         expect(
             places.buildTextSearchUrl(query: "123 Main Street", radius: 500),
             equals(
-                "https://maps.googleapis.com/maps/api/place/textsearch/json?key=$apiKey&query=${Uri.encodeComponent("123 Main Street")}&radius=500"));
+                "https://maps.googleapis.com/maps/api/place/textsearch/json?query=${Uri.encodeComponent("123 Main Street")}&radius=500&key=$apiKey"));
       });
 
       test("with language", () {
         expect(
             places.buildTextSearchUrl(query: "123 Main Street", language: "fr"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/textsearch/json?key=$apiKey&query=${Uri.encodeComponent("123 Main Street")}&language=fr"));
+                "https://maps.googleapis.com/maps/api/place/textsearch/json?query=${Uri.encodeComponent("123 Main Street")}&language=fr&key=$apiKey"));
       });
 
       test("with minprice and maxprice", () {
@@ -155,14 +155,14 @@ launch([Client client]) async {
                 minprice: PriceLevel.free,
                 maxprice: PriceLevel.veryExpensive),
             equals(
-                "https://maps.googleapis.com/maps/api/place/textsearch/json?key=$apiKey&query=${Uri.encodeComponent("123 Main Street")}&minprice=0&maxprice=4"));
+                "https://maps.googleapis.com/maps/api/place/textsearch/json?query=${Uri.encodeComponent("123 Main Street")}&minprice=0&maxprice=4&key=$apiKey"));
       });
 
       test("with opennow", () {
         expect(
             places.buildTextSearchUrl(query: "123 Main Street", opennow: true),
             equals(
-                "https://maps.googleapis.com/maps/api/place/textsearch/json?key=$apiKey&query=${Uri.encodeComponent("123 Main Street")}&opennow=true"));
+                "https://maps.googleapis.com/maps/api/place/textsearch/json?query=${Uri.encodeComponent("123 Main Street")}&opennow=true&key=$apiKey"));
       });
 
       test("with pagetoken", () {
@@ -170,7 +170,7 @@ launch([Client client]) async {
             places.buildTextSearchUrl(
                 query: "123 Main Street", pagetoken: "egdsfdsfdsf"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/textsearch/json?key=$apiKey&query=${Uri.encodeComponent("123 Main Street")}&pagetoken=egdsfdsfdsf"));
+                "https://maps.googleapis.com/maps/api/place/textsearch/json?query=${Uri.encodeComponent("123 Main Street")}&pagetoken=egdsfdsfdsf&key=$apiKey"));
       });
 
       test("with type", () {
@@ -178,7 +178,7 @@ launch([Client client]) async {
             places.buildTextSearchUrl(
                 query: "123 Main Street", type: "hospital"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/textsearch/json?key=$apiKey&query=${Uri.encodeComponent("123 Main Street")}&type=hospital"));
+                "https://maps.googleapis.com/maps/api/place/textsearch/json?query=${Uri.encodeComponent("123 Main Street")}&type=hospital&key=$apiKey"));
       });
     });
 
@@ -187,14 +187,14 @@ launch([Client client]) async {
         expect(
             places.buildDetailsUrl(placeId: "PLACE_ID"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/details/json?key=$apiKey&placeid=PLACE_ID"));
+                "https://maps.googleapis.com/maps/api/place/details/json?placeid=PLACE_ID&key=$apiKey"));
       });
 
       test("with reference", () {
         expect(
             places.buildDetailsUrl(reference: "REF"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/details/json?key=$apiKey&reference=REF"));
+                "https://maps.googleapis.com/maps/api/place/details/json?reference=REF&key=$apiKey"));
       });
 
       test("with extensions", () {
@@ -202,14 +202,14 @@ launch([Client client]) async {
             places.buildDetailsUrl(
                 placeId: "PLACE_ID", extensions: "review_summary"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/details/json?key=$apiKey&placeid=PLACE_ID&extensions=review_summary"));
+                "https://maps.googleapis.com/maps/api/place/details/json?placeid=PLACE_ID&extensions=review_summary&key=$apiKey"));
       });
 
       test("with extensions", () {
         expect(
             places.buildDetailsUrl(placeId: "PLACE_ID", language: "fr"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/details/json?key=$apiKey&placeid=PLACE_ID&language=fr"));
+                "https://maps.googleapis.com/maps/api/place/details/json?placeid=PLACE_ID&language=fr&key=$apiKey"));
       });
 
       test("with place_id and reference", () {
@@ -233,14 +233,14 @@ launch([Client client]) async {
         expect(
             places.buildAutocompleteUrl(input: "Amoeba"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=$apiKey&input=Amoeba"));
+                "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&key=$apiKey"));
       });
 
       test("with offset", () {
         expect(
             places.buildAutocompleteUrl(input: "Amoeba", offset: 3),
             equals(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=$apiKey&input=Amoeba&offset=3"));
+                "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&offset=3&key=$apiKey"));
       });
 
       test("with location", () {
@@ -249,21 +249,21 @@ launch([Client client]) async {
                 input: "Amoeba",
                 location: new Location(-33.8670522, 151.1957362)),
             equals(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=$apiKey&input=Amoeba&location=-33.8670522,151.1957362"));
+                "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&location=-33.8670522,151.1957362&key=$apiKey"));
       });
 
       test("with radius", () {
         expect(
             places.buildAutocompleteUrl(input: "Amoeba", radius: 500),
             equals(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=$apiKey&input=Amoeba&radius=500"));
+                "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&radius=500&key=$apiKey"));
       });
 
       test("with language", () {
         expect(
             places.buildAutocompleteUrl(input: "Amoeba", language: "fr"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=$apiKey&input=Amoeba&language=fr"));
+                "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&language=fr&key=$apiKey"));
       });
 
       test("with types", () {
@@ -271,7 +271,7 @@ launch([Client client]) async {
             places.buildAutocompleteUrl(
                 input: "Amoeba", types: ["geocode", "establishment"]),
             equals(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=$apiKey&input=Amoeba&types=geocode|establishment"));
+                "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&types=geocode|establishment&key=$apiKey"));
       });
 
       test("with components", () {
@@ -280,14 +280,14 @@ launch([Client client]) async {
                 input: "Amoeba",
                 components: [new Component(Component.country, "fr")]),
             equals(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=$apiKey&input=Amoeba&components=country:fr"));
+                "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&components=country:fr&key=$apiKey"));
       });
 
       test("with strictbounds", () {
         expect(
             places.buildAutocompleteUrl(input: "Amoeba", strictbounds: true),
             equals(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=$apiKey&input=Amoeba&strictbounds=true"));
+                "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&strictbounds=true&key=$apiKey"));
       });
     });
 
@@ -296,14 +296,14 @@ launch([Client client]) async {
         expect(
             places.buildQueryAutocompleteUrl(input: "Amoeba"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?key=$apiKey&input=Amoeba"));
+                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&key=$apiKey"));
       });
 
       test("with offset", () {
         expect(
             places.buildQueryAutocompleteUrl(input: "Amoeba", offset: 3),
             equals(
-                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?key=$apiKey&input=Amoeba&offset=3"));
+                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&offset=3&key=$apiKey"));
       });
 
       test("with location", () {
@@ -312,21 +312,21 @@ launch([Client client]) async {
                 input: "Amoeba",
                 location: new Location(-33.8670522, 151.1957362)),
             equals(
-                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?key=$apiKey&input=Amoeba&location=-33.8670522,151.1957362"));
+                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&location=-33.8670522,151.1957362&key=$apiKey"));
       });
 
       test("with radius", () {
         expect(
             places.buildQueryAutocompleteUrl(input: "Amoeba", radius: 500),
             equals(
-                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?key=$apiKey&input=Amoeba&radius=500"));
+                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&radius=500&key=$apiKey"));
       });
 
       test("with language", () {
         expect(
             places.buildQueryAutocompleteUrl(input: "Amoeba", language: "fr"),
             equals(
-                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?key=$apiKey&input=Amoeba&language=fr"));
+                "https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&language=fr&key=$apiKey"));
       });
     });
 


### PR DESCRIPTION
In case the google maps webservice will be used behind a proxy, it is necessary to configure the url of the proxy. For this reason the baseUrl argument is introduced.

It is not best practice to store the apiKey in the app. We are using a proxy which adds the apiKey to the request. This ensures that I do not have to store the apiKey in the application.
For this reason it was needed to make the apiKey optional. To achieve this I changed the constructor to use named arguments.

This leads to an api breaking change, sorry for that but the advantage of this change is that a future argument change will not break the api.
If this should be a problem. I'm open for any suggestions.