### PR TITLE
Add optional opennow parameter to nearby search

### DIFF
--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -39,6 +39,7 @@ class GoogleMapsPlaces extends GoogleWebService {
     PriceLevel maxprice,
     String name,
     String pagetoken,
+    bool opennow,
   }) async {
     final url = buildNearbySearchUrl(
       location: location,
@@ -50,6 +51,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       maxprice: maxprice,
       name: name,
       pagetoken: pagetoken,
+      opennow: opennow,
     );
     return _decodeSearchResponse(await doGet(url));
   }
@@ -64,6 +66,7 @@ class GoogleMapsPlaces extends GoogleWebService {
     PriceLevel maxprice,
     String name,
     String pagetoken,
+    bool opennow,
   }) async {
     final url = buildNearbySearchUrl(
       location: location,
@@ -75,6 +78,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       maxprice: maxprice,
       name: name,
       pagetoken: pagetoken,
+      opennow: opennow,
     );
     return _decodeSearchResponse(await doGet(url));
   }
@@ -181,6 +185,7 @@ class GoogleMapsPlaces extends GoogleWebService {
     String name,
     String rankby,
     String pagetoken,
+    bool opennow,
   }) {
     if (radius != null && rankby != null) {
       throw ArgumentError(
@@ -206,6 +211,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       'name': name,
       'rankby': rankby,
       'pagetoken': pagetoken,
+      'opennow': opennow,
     };
 
     if (apiKey != null) {

--- a/test/places_test.dart
+++ b/test/places_test.dart
@@ -61,6 +61,18 @@ Future<void> main() async {
                 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522,151.1957362&radius=500&minprice=0&maxprice=4&key=$apiKey'));
       });
 
+      test('with opennow', () {
+        String url = places.buildNearbySearchUrl(
+            location: Location(-33.8670522, 151.1957362),
+            radius: 500,
+            opennow: true);
+
+        expect(
+            url,
+            equals(
+                'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522,151.1957362&radius=500&opennow=true&key=$apiKey'));
+      });
+
       test('build url with name', () {
         String url = places.buildNearbySearchUrl(
             location: Location(-33.8670522, 151.1957362),


### PR DESCRIPTION
According to the documentation the optional parameter opennow is for:

"Returns only those places that are open for business at the time the query is
sent. Places that do not specify opening hours in the Google Places database
will not be returned if you include this parameter in your query."

Source: https://developers.google.com/places/web-service/search#PlaceSearchRequests