### PR TITLE
Fix type mismatch on PlacesDetailsResponse.fromJson(json)

### DIFF
--- a/lib/src/geocoding.dart
+++ b/lib/src/geocoding.dart
@@ -217,7 +217,8 @@ class StreetAddress {
   );
 
   factory StreetAddress.fromGeocodingResult(GeocodingResult geocodingResult) {
-    if (geocodingResult == null || !geocodingResult.types.contains('street_address')) return null;
+    if (geocodingResult == null ||
+        !geocodingResult.types.contains('street_address')) return null;
 
     AddressComponent search(String type) {
       return geocodingResult.addressComponents.firstWhere(

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -733,7 +733,7 @@ class PlacesDetailsResponse extends GoogleResponse<PlaceDetails> {
       ? PlacesDetailsResponse(
           json['status'],
           json['error_message'],
-          json['result'] != null ? PlaceDetails.fromJson(json['result']) : [],
+          json['result'] != null ? PlaceDetails.fromJson(json['result']) : null,
           json['html_attributions'] != null
               ? (json['html_attributions'] as List)?.cast<String>()
               : [])


### PR DESCRIPTION
Fix type mismatch on PlacesDetailsResponse.fromJson(json) where result should receive null rather than [] (List<dynamic>) when json['result'] is equal to null.

Fixes issue #57 and #53