### PR TITLE
fix(autocomplete): add origin parameter to autocomplete queries

### DIFF
--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -139,6 +139,7 @@ class GoogleMapsPlaces extends GoogleWebService {
     String input, {
     String sessionToken,
     num offset,
+    Location origin,
     Location location,
     num radius,
     String language,
@@ -150,6 +151,7 @@ class GoogleMapsPlaces extends GoogleWebService {
     final url = buildAutocompleteUrl(
       sessionToken: sessionToken,
       input: input,
+      origin: origin,
       location: location,
       offset: offset,
       radius: radius,
@@ -162,10 +164,17 @@ class GoogleMapsPlaces extends GoogleWebService {
     return _decodeAutocompleteResponse(await doGet(url));
   }
 
-  Future<PlacesAutocompleteResponse> queryAutocomplete(String input,
-      {num offset, Location location, num radius, String language}) async {
+  Future<PlacesAutocompleteResponse> queryAutocomplete(
+    String input, {
+    num offset,
+    Location origin,
+    Location location,
+    num radius,
+    String language,
+  }) async {
     final url = buildQueryAutocompleteUrl(
       input: input,
+      origin: origin,
       location: location,
       offset: offset,
       radius: radius,
@@ -287,6 +296,7 @@ class GoogleMapsPlaces extends GoogleWebService {
     String input,
     String sessionToken,
     num offset,
+    Location origin,
     Location location,
     num radius,
     String language,
@@ -298,6 +308,7 @@ class GoogleMapsPlaces extends GoogleWebService {
     final params = {
       'input': input != null ? Uri.encodeComponent(input) : null,
       'language': language,
+      'origin': origin,
       'location': location,
       'radius': radius,
       'types': types,
@@ -318,6 +329,7 @@ class GoogleMapsPlaces extends GoogleWebService {
   String buildQueryAutocompleteUrl({
     String input,
     num offset,
+    Location origin,
     Location location,
     num radius,
     String language,
@@ -325,6 +337,7 @@ class GoogleMapsPlaces extends GoogleWebService {
     final params = {
       'input': input != null ? Uri.encodeComponent(input) : null,
       'language': language,
+      'origin': origin,
       'location': location,
       'radius': radius,
       'offset': offset,
@@ -816,6 +829,7 @@ class Prediction {
   final String description;
   final String id;
   final List<Term> terms;
+  final int distanceMeters;
 
   /// JSON place_id
   final String placeId;
@@ -831,6 +845,7 @@ class Prediction {
       this.description,
       this.id,
       this.terms,
+      this.distanceMeters,
       this.placeId,
       this.reference,
       this.types,
@@ -842,6 +857,7 @@ class Prediction {
           json['description'],
           json['id'],
           json['terms']?.map((t) => Term.fromJson(t))?.toList()?.cast<Term>(),
+          json['distance_meters'],
           json['place_id'],
           json['reference'],
           json['types'] != null ? (json['types'] as List)?.cast<String>() : [],
@@ -864,6 +880,22 @@ class Term {
 
   factory Term.fromJson(Map json) =>
       json != null ? Term(json['offset'], json['value']) : null;
+
+  @override
+  String toString() {
+    return 'Term{offset: $offset, value: $value}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Term &&
+          runtimeType == other.runtimeType &&
+          offset == other.offset &&
+          value == other.value;
+
+  @override
+  int get hashCode => offset.hashCode ^ value.hashCode;
 }
 
 class MatchedSubstring {
@@ -874,6 +906,22 @@ class MatchedSubstring {
 
   factory MatchedSubstring.fromJson(Map json) =>
       json != null ? MatchedSubstring(json['offset'], json['length']) : null;
+
+  @override
+  String toString() {
+    return 'MatchedSubstring{offset: $offset, length: $length}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MatchedSubstring &&
+          runtimeType == other.runtimeType &&
+          offset == other.offset &&
+          length == other.length;
+
+  @override
+  int get hashCode => offset.hashCode ^ length.hashCode;
 }
 
 class StructuredFormatting {

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -167,14 +167,12 @@ class GoogleMapsPlaces extends GoogleWebService {
   Future<PlacesAutocompleteResponse> queryAutocomplete(
     String input, {
     num offset,
-    Location origin,
     Location location,
     num radius,
     String language,
   }) async {
     final url = buildQueryAutocompleteUrl(
       input: input,
-      origin: origin,
       location: location,
       offset: offset,
       radius: radius,
@@ -329,7 +327,6 @@ class GoogleMapsPlaces extends GoogleWebService {
   String buildQueryAutocompleteUrl({
     String input,
     num offset,
-    Location origin,
     Location location,
     num radius,
     String language,
@@ -337,7 +334,6 @@ class GoogleMapsPlaces extends GoogleWebService {
     final params = {
       'input': input != null ? Uri.encodeComponent(input) : null,
       'language': language,
-      'origin': origin,
       'location': location,
       'radius': radius,
       'offset': offset,

--- a/test/places_test.dart
+++ b/test/places_test.dart
@@ -351,16 +351,6 @@ Future<void> main() async {
                 'https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&location=-33.8670522,151.1957362&key=$apiKey'));
       });
 
-      test('with origin', () {
-        expect(
-            places.buildQueryAutocompleteUrl(
-              input: 'Amoeba',
-              origin: Location(-33.8670522, 151.1957362),
-            ),
-            equals(
-                'https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&origin=-33.8670522,151.1957362&key=$apiKey'));
-      });
-
       test('with radius', () {
         expect(
             places.buildQueryAutocompleteUrl(input: 'Amoeba', radius: 500),

--- a/test/places_test.dart
+++ b/test/places_test.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
-import 'package:test/test.dart';
+
 import 'package:google_maps_webservice/places.dart';
+import 'package:test/test.dart';
 
 Future<void> main() async {
   final apiKey = 'MY_API_KEY';
@@ -276,6 +277,16 @@ Future<void> main() async {
                 'https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&location=-33.8670522,151.1957362&key=$apiKey'));
       });
 
+      test('with origin', () {
+        expect(
+            places.buildAutocompleteUrl(
+              input: 'Amoeba',
+              origin: Location(-33.8670522, 151.1957362),
+            ),
+            equals(
+                'https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Amoeba&origin=-33.8670522,151.1957362&key=$apiKey'));
+      });
+
       test('with radius', () {
         expect(
             places.buildAutocompleteUrl(input: 'Amoeba', radius: 500),
@@ -340,6 +351,16 @@ Future<void> main() async {
                 'https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&location=-33.8670522,151.1957362&key=$apiKey'));
       });
 
+      test('with origin', () {
+        expect(
+            places.buildQueryAutocompleteUrl(
+              input: 'Amoeba',
+              origin: Location(-33.8670522, 151.1957362),
+            ),
+            equals(
+                'https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=Amoeba&origin=-33.8670522,151.1957362&key=$apiKey'));
+      });
+
       test('with radius', () {
         expect(
             places.buildQueryAutocompleteUrl(input: 'Amoeba', radius: 500),
@@ -355,9 +376,9 @@ Future<void> main() async {
       });
     });
 
-    test('decode response', () {
+    test('decode search response', () {
       var response =
-          PlacesSearchResponse.fromJson(json.decode(_responseExample));
+          PlacesSearchResponse.fromJson(json.decode(_searchResponseExample));
 
       expect(response.isOkay, isTrue);
       expect(response.results, hasLength(equals(4)));
@@ -394,10 +415,33 @@ Future<void> main() async {
       expect(response.results.first.vicinity,
           equals('Pyrmont Bay Wharf Darling Dr, Sydney'));
     });
+
+    test('decode autocomplete response', () {
+      final decoded = json.decode(_autocompleteResponseExample);
+      final response = PlacesAutocompleteResponse.fromJson(decoded);
+
+      expect(response.isOkay, isTrue);
+      expect(response.errorMessage, isNull);
+
+      expect(response.predictions, hasLength(3));
+
+      final p1 = response.predictions.first;
+
+      expect(p1.description, 'Paris, France');
+      expect(p1.distanceMeters, 8030004);
+      expect(p1.id, '691b237b0322f28988f3ce03e321ff72a12167fd');
+      expect(p1.matchedSubstrings, hasLength(1));
+      expect(p1.matchedSubstrings.first, MatchedSubstring(0, 5));
+      expect(p1.placeId, 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ');
+      expect(p1.reference,
+          'CjQlAAAA_KB6EEceSTfkteSSF6U0pvumHCoLUboRcDlAH05N1pZJLmOQbYmboEi0SwXBSoI2EhAhj249tFDCVh4R-PXZkPK8GhTBmp_6_lWljaf1joVs1SH2ttB_tw');
+      expect(p1.terms, [Term(0, 'Paris'), Term(7, 'France')]);
+      expect(p1.types, ['locality', 'political', 'geocode']);
+    });
   });
 }
 
-final _responseExample = '''
+final _searchResponseExample = '''
 {
    "html_attributions" : [],
    "results" : [
@@ -514,5 +558,127 @@ final _responseExample = '''
       }
    ],
    "status" : "OK"
+}
+''';
+
+final _autocompleteResponseExample = '''
+{
+  "status": "OK",
+  "predictions" : [
+      {
+         "description" : "Paris, France",
+         "distance_meters" : 8030004,
+         "id" : "691b237b0322f28988f3ce03e321ff72a12167fd",
+         "matched_substrings" : [
+            {
+               "length" : 5,
+               "offset" : 0
+            }
+         ],
+         "place_id" : "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",
+         "reference" : "CjQlAAAA_KB6EEceSTfkteSSF6U0pvumHCoLUboRcDlAH05N1pZJLmOQbYmboEi0SwXBSoI2EhAhj249tFDCVh4R-PXZkPK8GhTBmp_6_lWljaf1joVs1SH2ttB_tw",
+         "terms" : [
+            {
+               "offset" : 0,
+               "value" : "Paris"
+            },
+            {
+               "offset" : 7,
+               "value" : "France"
+            }
+         ],
+         "types" : [ "locality", "political", "geocode" ]
+      },
+      {
+         "description" : "Paris-Madrid Grocery (Spanish Table Seattle), Western Avenue, Seattle, WA, USA",
+         "distance_meters" : 12597,
+         "id" : "f4231a82cfe0633a6a32e63538e61c18277d01c0",
+         "matched_substrings" : [
+            {
+               "length" : 5,
+               "offset" : 0
+            }
+         ],
+         "place_id" : "ChIJHcYlZ7JqkFQRlpy-6pytmPI",
+         "reference" : "ChIJHcYlZ7JqkFQRlpy-6pytmPI",
+         "structured_formatting" : {
+            "main_text" : "Paris-Madrid Grocery (Spanish Table Seattle)",
+            "main_text_matched_substrings" : [
+               {
+                  "length" : 5,
+                  "offset" : 0
+               }
+            ],
+            "secondary_text" : "Western Avenue, Seattle, WA, USA"
+         },
+         "terms" : [
+            {
+               "offset" : 0,
+               "value" : "Paris-Madrid Grocery (Spanish Table Seattle)"
+            },
+            {
+               "offset" : 46,
+               "value" : "Western Avenue"
+            },
+            {
+               "offset" : 62,
+               "value" : "Seattle"
+            },
+            {
+               "offset" : 71,
+               "value" : "WA"
+            },
+            {
+               "offset" : 75,
+               "value" : "USA"
+            }
+         ],
+         "types" : [
+            "grocery_or_supermarket",
+            "food",
+            "store",
+            "point_of_interest",
+            "establishment"
+         ]
+      },
+      {
+         "description" : "Paris, TX, USA",
+         "distance_meters" : 2712292,
+         "id" : "518e47f3d7f39277eb3bc895cb84419c2b43b5ac",
+         "matched_substrings" : [
+            {
+               "length" : 5,
+               "offset" : 0
+            }
+         ],
+         "place_id" : "ChIJmysnFgZYSoYRSfPTL2YJuck",
+         "reference" : "ChIJmysnFgZYSoYRSfPTL2YJuck",
+         "structured_formatting" : {
+            "main_text" : "Paris",
+            "main_text_matched_substrings" : [
+               {
+                  "length" : 5,
+                  "offset" : 0
+               }
+            ],
+            "secondary_text" : "TX, USA"
+         },
+         "terms" : [
+            {
+               "offset" : 0,
+               "value" : "Paris"
+            },
+            {
+               "offset" : 7,
+               "value" : "TX"
+            },
+            {
+               "offset" : 11,
+               "value" : "USA"
+            }
+         ],
+         "types" : [ "locality", "political", "geocode" ]
+      }
+  ]
 }
 ''';


### PR DESCRIPTION
When the `origin` parameter is included, the response will contain the distance in meters for each
response. The paramter has been added to both `autocomplete` and `queryAutocomplete`.

Also added `distanceMeters` to the prediction response and added test cases for decoding JSON
responses.

Fixes issue lejard-h/google_maps_webservice#74