### PR TITLE
Add to support restricted API keys

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,6 +1,7 @@
 library google_maps_webservice.utils;
 
 import 'dart:async';
+import 'package:google_api_headers/google_api_headers.dart';
 import 'package:meta/meta.dart';
 import 'package:http/http.dart';
 
@@ -50,13 +51,17 @@ abstract class GoogleWebService {
   void dispose() => httpClient.close();
 
   @protected
-  Future<Response> doGet(String url) => httpClient.get(url);
+  Future<Response> doGet(String url) async {
+    final headers = await GoogleApiHeaders().getHeaders();
+    return httpClient.get(url, headers: headers);
+  }
 
   @protected
-  Future<Response> doPost(String url, String body) {
-    return httpClient.post(url, body: body, headers: {
+  Future<Response> doPost(String url, String body) async {
+    final headers = {
       'Content-type': 'application/json',
-    });
+    }..addAll(await GoogleApiHeaders().getHeaders());
+    return httpClient.post(url, body: body, headers: headers);
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,9 +4,10 @@ version: 0.0.18
 homepage: https://github.com/lejard-h/google_maps_webservice
 
 environment:
-  sdk: '>=1.20.1 <3.0.0'
+  sdk: ">=1.20.1 <3.0.0"
 
 dependencies:
+  google_api_headers: ">=0.1.0 <1.0.0"
   http: ">=0.11.0 <1.0.0"
   meta: ^1.1.0
 


### PR DESCRIPTION
Add to support calling Google APIs when the API key is restricted to iOS or Android apps.

Related issues: #28 #85 