### PR TITLE
Add to allow custom headers for calling google apis

### DIFF
--- a/lib/src/directions.dart
+++ b/lib/src/directions.dart
@@ -14,11 +14,13 @@ class GoogleMapsDirections extends GoogleWebService {
     String apiKey,
     String baseUrl,
     Client httpClient,
+    Map<String, dynamic> apiHeaders,
   }) : super(
           apiKey: apiKey,
           baseUrl: baseUrl,
           url: _directionsUrl,
           httpClient: httpClient,
+          apiHeaders: apiHeaders,
         );
 
   Future<DirectionsResponse> directions(
@@ -55,7 +57,7 @@ class GoogleMapsDirections extends GoogleWebService {
       trafficModel: trafficModel,
       transitRoutingPreference: transitRoutingPreference,
     );
-    return _decode(await doGet(url));
+    return _decode(await doGet(url, headers: apiHeaders));
   }
 
   Future<DirectionsResponse> directionsWithLocation(
@@ -178,7 +180,8 @@ class GoogleMapsDirections extends GoogleWebService {
       'mode': travelModeToString(travelMode),
       'waypoints': waypoints,
       'alternatives': alternatives,
-      'avoid': avoids?.map(routeTypeToString)?.join('|') ?? routeTypeToString(avoid),
+      'avoid':
+          avoids?.map(routeTypeToString)?.join('|') ?? routeTypeToString(avoid),
       'language': language,
       'units': unitToString(units),
       'region': region,

--- a/lib/src/distance.dart
+++ b/lib/src/distance.dart
@@ -16,11 +16,14 @@ class GoogleDistanceMatrix extends GoogleWebService {
     String apiKey,
     String baseUrl,
     Client httpClient,
+    Map<String, dynamic> apiHeaders,
   }) : super(
-            apiKey: apiKey,
-            baseUrl: baseUrl,
-            url: _distanceUrl,
-            httpClient: httpClient);
+          apiKey: apiKey,
+          baseUrl: baseUrl,
+          url: _distanceUrl,
+          httpClient: httpClient,
+          apiHeaders: apiHeaders,
+        );
 
   Future<DistanceResponse> _distance(
     List<dynamic> origin,
@@ -53,7 +56,7 @@ class GoogleDistanceMatrix extends GoogleWebService {
       transitRoutingPreference: transitRoutingPreference,
     );
 
-    return _decode(await doGet(url));
+    return _decode(await doGet(url, headers: apiHeaders));
   }
 
   Future<DistanceResponse> distanceWithLocation(

--- a/lib/src/geocoding.dart
+++ b/lib/src/geocoding.dart
@@ -14,11 +14,13 @@ class GoogleMapsGeocoding extends GoogleWebService {
     String apiKey,
     String baseUrl,
     Client httpClient,
+    Map<String, dynamic> apiHeaders,
   }) : super(
           apiKey: apiKey,
           baseUrl: baseUrl,
           url: _geocodeUrl,
           httpClient: httpClient,
+          apiHeaders: apiHeaders,
         );
 
   Future<GeocodingResponse> searchByAddress(
@@ -34,7 +36,7 @@ class GoogleMapsGeocoding extends GoogleWebService {
         language: language,
         region: region,
         components: components);
-    return _decode(await doGet(url));
+    return _decode(await doGet(url, headers: apiHeaders));
   }
 
   Future<GeocodingResponse> searchByComponents(
@@ -48,7 +50,7 @@ class GoogleMapsGeocoding extends GoogleWebService {
         language: language,
         region: region,
         components: components);
-    return _decode(await doGet(url));
+    return _decode(await doGet(url, headers: apiHeaders));
   }
 
   Future<GeocodingResponse> searchByLocation(
@@ -62,7 +64,7 @@ class GoogleMapsGeocoding extends GoogleWebService {
         language: language,
         resultType: resultType,
         locationType: locationType);
-    return _decode(await doGet(url));
+    return _decode(await doGet(url, headers: apiHeaders));
   }
 
   Future<GeocodingResponse> searchByPlaceId(
@@ -76,7 +78,7 @@ class GoogleMapsGeocoding extends GoogleWebService {
         language: language,
         resultType: resultType,
         locationType: locationType);
-    return _decode(await doGet(url));
+    return _decode(await doGet(url, headers: apiHeaders));
   }
 
   String buildUrl({

--- a/lib/src/geolocation.dart
+++ b/lib/src/geolocation.dart
@@ -40,15 +40,23 @@ class GoogleMapsGeolocation extends GoogleWebService {
         cellTowers: cellTowers,
         wifiAccessPoints: wifiAccessPoints);
 
-    return _decode(await doPost(buildUrl(), json.encode(body)));
+    return _decode(await doPost(
+      buildUrl(),
+      json.encode(body),
+      headers: apiHeaders,
+    ));
   }
 
   Future<GeolocationResponse> getGeolocationFromMap(Map params) async {
-    return _decode(await doPost(buildUrl(), json.encode(params)));
+    return _decode(await doPost(
+      buildUrl(),
+      json.encode(params),
+      headers: apiHeaders,
+    ));
   }
 
   Future<GeolocationResponse> currentGeolocation() async =>
-      _decode(await doPost(buildUrl(), json.encode({})));
+      _decode(await doPost(buildUrl(), json.encode({}), headers: apiHeaders));
 
   String buildUrl() {
     return "$url?${buildQuery({"key": apiKey})}";

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -23,11 +23,14 @@ class GoogleMapsPlaces extends GoogleWebService {
     String apiKey,
     String baseUrl,
     Client httpClient,
+    Map<String, dynamic> apiHeaders,
   }) : super(
-            apiKey: apiKey,
-            baseUrl: baseUrl,
-            url: _placesUrl,
-            httpClient: httpClient);
+          apiKey: apiKey,
+          baseUrl: baseUrl,
+          url: _placesUrl,
+          httpClient: httpClient,
+          apiHeaders: apiHeaders,
+        );
 
   Future<PlacesSearchResponse> searchNearbyWithRadius(
     Location location,
@@ -51,7 +54,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       name: name,
       pagetoken: pagetoken,
     );
-    return _decodeSearchResponse(await doGet(url));
+    return _decodeSearchResponse(await doGet(url, headers: apiHeaders));
   }
 
   Future<PlacesSearchResponse> searchNearbyWithRankBy(
@@ -76,7 +79,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       name: name,
       pagetoken: pagetoken,
     );
-    return _decodeSearchResponse(await doGet(url));
+    return _decodeSearchResponse(await doGet(url, headers: apiHeaders));
   }
 
   Future<PlacesSearchResponse> searchByText(
@@ -101,7 +104,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       pagetoken: pagetoken,
       opennow: opennow,
     );
-    return _decodeSearchResponse(await doGet(url));
+    return _decodeSearchResponse(await doGet(url, headers: apiHeaders));
   }
 
   Future<PlacesDetailsResponse> getDetailsByPlaceId(String placeId,
@@ -116,7 +119,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       language: language,
       region: region,
     );
-    return _decodeDetailsResponse(await doGet(url));
+    return _decodeDetailsResponse(await doGet(url, headers: apiHeaders));
   }
 
   @deprecated
@@ -132,7 +135,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       fields: fields,
       language: language,
     );
-    return _decodeDetailsResponse(await doGet(url));
+    return _decodeDetailsResponse(await doGet(url, headers: apiHeaders));
   }
 
   Future<PlacesAutocompleteResponse> autocomplete(
@@ -161,7 +164,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       strictbounds: strictbounds,
       region: region,
     );
-    return _decodeAutocompleteResponse(await doGet(url));
+    return _decodeAutocompleteResponse(await doGet(url, headers: apiHeaders));
   }
 
   Future<PlacesAutocompleteResponse> queryAutocomplete(
@@ -178,7 +181,7 @@ class GoogleMapsPlaces extends GoogleWebService {
       radius: radius,
       language: language,
     );
-    return _decodeAutocompleteResponse(await doGet(url));
+    return _decodeAutocompleteResponse(await doGet(url, headers: apiHeaders));
   }
 
   String buildNearbySearchUrl({

--- a/lib/src/timezone.dart
+++ b/lib/src/timezone.dart
@@ -14,11 +14,13 @@ class GoogleMapsTimezone extends GoogleWebService {
     String apiKey,
     String baseUrl,
     Client httpClient,
+    Map<String, dynamic> apiHeaders,
   }) : super(
           apiKey: apiKey,
           baseUrl: baseUrl,
           url: _timezoneUrl,
           httpClient: httpClient,
+          apiHeaders: apiHeaders,
         );
 
   /// Retrieves time zone information for the specified location and the timestamp.
@@ -30,7 +32,7 @@ class GoogleMapsTimezone extends GoogleWebService {
     String language,
   }) async {
     final requestUrl = buildUrl(location, timestamp, language);
-    return _decode(await doGet(requestUrl));
+    return _decode(await doGet(requestUrl, headers: apiHeaders));
   }
 
   String buildUrl(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -16,21 +16,28 @@ abstract class GoogleWebService {
   @protected
   final String _apiKey;
 
+  @protected
+  final Map<String, dynamic> _apiHeaders;
+
   String get url => _url;
 
   Client get httpClient => _httpClient;
 
   String get apiKey => _apiKey;
 
+  Map<String, dynamic> get apiHeaders => _apiHeaders;
+
   GoogleWebService({
     String apiKey,
     String baseUrl,
     @required String url,
     Client httpClient,
+    Map<String, dynamic> apiHeaders,
   })  : assert(url != null),
         _url = '${baseUrl ?? kGMapsUrl}$url',
         _httpClient = httpClient ?? Client(),
-        _apiKey = apiKey;
+        _apiKey = apiKey,
+        _apiHeaders = apiHeaders;
 
   @protected
   String buildQuery(Map<String, dynamic> params) {
@@ -50,13 +57,21 @@ abstract class GoogleWebService {
   void dispose() => httpClient.close();
 
   @protected
-  Future<Response> doGet(String url) => httpClient.get(url);
+  Future<Response> doGet(String url, {Map<String, dynamic> headers}) {
+    return httpClient.get(url, headers: headers);
+  }
 
   @protected
-  Future<Response> doPost(String url, String body) {
-    return httpClient.post(url, body: body, headers: {
+  Future<Response> doPost(
+    String url,
+    String body, {
+    Map<String, dynamic> headers,
+  }) {
+    final postHeaders = {
       'Content-type': 'application/json',
-    });
+    };
+    if (headers != null) postHeaders.addAll(headers);
+    return httpClient.post(url, body: body, headers: postHeaders);
   }
 }
 


### PR DESCRIPTION
- Add `apiHeaders` to `GoogleWebService` for users to specify the headers to be used when calling the Google APIs.
- Update `doGet` and `doPost` functions to use the user defined headers if they are provided

**Example usage:**
When using app restricted API keys, users can specify the custom headers that are required to use the restricted keys, which also address the issues #28 #85.