### PR TITLE
make PlacesSearchResult.id optional

### DIFF
--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -594,7 +594,7 @@ class PlacesSearchResult {
   @JsonKey(defaultValue: false)
   final bool permanentlyClosed;
 
-  final String id;
+  final String? id;
 
   final String reference;
 

--- a/lib/src/places.g.dart
+++ b/lib/src/places.g.dart
@@ -34,7 +34,7 @@ Map<String, dynamic> _$PlacesSearchResponseToJson(
 
 PlacesSearchResult _$PlacesSearchResultFromJson(Map<String, dynamic> json) {
   return PlacesSearchResult(
-    id: json['id'] as String,
+    id: json['id'] as String?,
     reference: json['reference'] as String,
     name: json['name'] as String,
     placeId: json['place_id'] as String,


### PR DESCRIPTION
Make PlacesSearchResult.id optional as it caused a crash when calling `GoogleMapsPlaces.searchByText` as the id was not there.  might solve #103 **not well testet**