### PR TITLE
utcOffset in PlaceDetails is now nullable.

### DIFF
--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -672,7 +672,7 @@ class PlaceDetails {
   final String? vicinity;
 
   /// JSON utc_offset
-  final num utcOffset;
+  final num? utcOffset;
 
   final String? website;
 

--- a/lib/src/places.g.dart
+++ b/lib/src/places.g.dart
@@ -136,7 +136,7 @@ PlaceDetails _$PlaceDetailsFromJson(Map<String, dynamic> json) {
     adrAddress: json['adr_address'] as String?,
     name: json['name'] as String,
     placeId: json['place_id'] as String,
-    utcOffset: json['utc_offset'] as num,
+    utcOffset: json['utc_offset'] as num?,
     id: json['id'] as String?,
     internationalPhoneNumber: json['international_phone_number'] as String?,
     addressComponents: (json['address_components'] as List<dynamic>?)


### PR DESCRIPTION
The utcOffset field in PlaceDetails is currently defined as num Type however the PlacesDetails API states that it is an optional field returned in the response.

In the `places_autocomplete.dart` example, there are no fields passed in the details request, which results in all fields being returned (including utcOffset), but when a subset of fields are defined, the utcOffset may not be returned.

```
    // get detail of the first result
    var details = await places.getDetailsByPlaceId(
      placeId,
      sessionToken: sessionToken,
      // fields: [
      //   'place_id',
      //   'name',
      //   'formatted_address',
      //   'geometry',
      // ],
    );
```

This PR correctly changes the type of utcOffset to num? to handle cases where utcOffset maybe null.
Fixes [103](https://github.com/lejard-h/google_maps_webservice/issues/103#issuecomment-813585612)