### PR TITLE
TravelModeExt.toApiString() fixed

### DIFF
--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -171,7 +171,7 @@ extension TravelModeExt on TravelMode {
   }
 
   String toApiString() {
-    return _$TravelModeEnumMap[this] ?? '';
+    return (_$TravelModeEnumMap[this] ?? '').toLowerCase();
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,13 +7,13 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  http: ^0.13.0
+  http: '>=0.13.0 <2.0.0'
   meta: ^1.3.0
   json_annotation: ^4.0.0
 
 dev_dependencies:
   test: ^1.16.0
   pedantic: ^1.10.0
-  build_runner: ^1.11.0
-  json_serializable: ^4.0.0
+  build_runner: ^2.4.6
+  json_serializable: ^6.7.1
   coverage: ^1.0.0


### PR DESCRIPTION
The 'mode' query param used in the url request must be lower case, currently TravelMode enum has a JsonValue parser that makes every value upper case to be able to parse from json responses but this is conflictive with the same travel mode enum value being used in the url query param.