### PR TITLE
Fix nullable field 'name' in place details (reopened)

### DIFF
--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -643,7 +643,7 @@ class PlaceDetails {
 
   final String? icon;
 
-  final String name;
+  final String? name;
 
   /// JSON opening_hours
   final OpeningHoursDetail? openingHours;

--- a/lib/src/places.g.dart
+++ b/lib/src/places.g.dart
@@ -134,7 +134,7 @@ const _$PriceLevelEnumMap = {
 PlaceDetails _$PlaceDetailsFromJson(Map<String, dynamic> json) {
   return PlaceDetails(
     adrAddress: json['adr_address'] as String?,
-    name: json['name'] as String,
+    name: json['name'] as String?,
     placeId: json['place_id'] as String,
     utcOffset: json['utc_offset'] as num?,
     id: json['id'] as String?,


### PR DESCRIPTION
The PlaceDetails name field can sometimes be null. This PR fixes the following error when this occurs:

```
_CastError (type 'Null' is not a subtype of type 'String' in type cast)
```

Reopens #116 as per request (https://github.com/lejard-h/google_maps_webservice/pull/116#issuecomment-863132939)