### PR TITLE
TravelMode must be lowercase in request.

### DIFF
--- a/lib/src/directions.dart
+++ b/lib/src/directions.dart
@@ -195,7 +195,7 @@ class GoogleMapsDirections extends GoogleWebService {
     }
 
     if (travelMode != null) {
-      params['mode'] = travelMode.toApiString();
+      params['mode'] = travelMode.toString().split('.').last;
     }
 
     if (alternatives) {


### PR DESCRIPTION
Although response is uppercase, request must be lowercase in directions api. Use uppercase in request would cause server always response 'DRIVING' mode.

Don't test other api that also use TravelMode enum. But I guess it has same problem.