### PR TITLE
T? for result

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: vporton # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/example/places_autocomplete.dart
+++ b/example/places_autocomplete.dart
@@ -26,9 +26,9 @@ Future<void> main() async {
     );
 
     print('\nDetails :');
-    print(details.result.formattedAddress);
-    print(details.result.formattedPhoneNumber);
-    print(details.result.url);
+    print(details.result!.formattedAddress);
+    print(details.result!.formattedPhoneNumber);
+    print(details.result!.url);
   } else {
     print(res.errorMessage);
   }

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -98,7 +98,7 @@ abstract class GoogleResponseList<T> extends GoogleResponseStatus {
 }
 
 abstract class GoogleResponse<T> extends GoogleResponseStatus {
-  final T result;
+  final T? result;
 
   GoogleResponse(String status, String? errorMessage, this.result)
       : super(status: status, errorMessage: errorMessage);

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -818,7 +818,7 @@ enum PriceLevel {
 
 @JsonSerializable()
 class PlacesDetailsResponse extends GoogleResponseStatus {
-  final PlaceDetails result;
+  final PlaceDetails? result;
 
   /// JSON html_attributions
   @JsonKey(defaultValue: <String>[])

--- a/lib/src/places.g.dart
+++ b/lib/src/places.g.dart
@@ -291,7 +291,7 @@ PlacesDetailsResponse _$PlacesDetailsResponseFromJson(
   return PlacesDetailsResponse(
     status: json['status'] as String,
     errorMessage: json['error_message'] as String?,
-    result: PlaceDetails.fromJson(json['result'] as Map<String, dynamic>),
+    result: json['status'] == 'OK' ? PlaceDetails.fromJson(json['result'] as Map<String, dynamic>) : null,
     htmlAttributions: (json['html_attributions'] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList() ??


### PR DESCRIPTION
Because Google response may be an error, use `T?` types instead of `T` for `.result`.

I leave `.results` (with `s`) as is, as `[]` is an adequate response on error.

WARNING: This PR is backward incompatible.