### PR TITLE
Update http package and delete build_runner package 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
 
 dependencies:
   http: ^1.1.0
-  meta: ^1.3.0
-  json_annotation: ^4.0.0
+  meta: ^1.10.0
+  json_annotation: ^4.8.1 
 
 dev_dependencies:
-  test: ^1.16.0
+  test: ^1.24.6
   pedantic: ^1.10.0
-  json_serializable: ^4.0.0
-  coverage: ^1.0.0
+  json_serializable: ^6.7.1
+  coverage: ^1.6.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  http: ^0.13.0
+  http: ^1.1.0
   meta: ^1.3.0
   json_annotation: ^4.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,5 @@ dependencies:
 dev_dependencies:
   test: ^1.16.0
   pedantic: ^1.10.0
-  build_runner: ^1.11.0
   json_serializable: ^4.0.0
   coverage: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   http: ^1.1.0
-  meta: ^1.10.0
+  meta: ^1.9.1
   json_annotation: ^4.8.1 
 
 dev_dependencies:


### PR DESCRIPTION
Since the build_runner package is not used but causes compatibility errors it is therefore deleted. The http package is updated to the latest version